### PR TITLE
Fix master_discovery error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo yum install epel-release
 sudo yum install python-pip
 sudo pip install -U pip
 sudo pip install apache-libcloud
-sudo pip install docker-py
+sudo pip install 'docker-py==1.9.0'
 sudo yum install git ansible
 ```
 

--- a/template/config.yaml
+++ b/template/config.yaml
@@ -3,6 +3,7 @@ bootstrap_url: http://{{ bootstrap_public_ip }}:{{ bootstrap_public_port }}
 cluster_name: {{ cluster_name }}
 exhibitor_storage_backend: static
 ip_detect_filename: /genconf/ip-detect
+master_discovery: static
 master_list:
 {% for master in groups['masters'] %}
 - {{ hostvars[master]['ip'] }}


### PR DESCRIPTION
This should fix the `master_discovery` error as seen in #7, and also pin the `docker-py` version
