### PR TITLE
chore(image): update CentOS image to v20161027

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -38,7 +38,7 @@ end_id: 0001
 
 gcloudbin: /usr/bin/gcloud
 
-image: '/centos-cloud/centos-7-v20160921'
+image: '/centos-cloud/centos-7-v20161027'
 
 bootstrap_public_port: 8080
 


### PR DESCRIPTION
### Summary of Changes

- update centos image version from `v20160921` to `v20161027`