### PR TITLE
chore: correct centos disk image version in README to v20161027

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The location of the gcloudbin binary. Default: /usr/local/bin/gcloud
 ```text
 image
 ```
-The disk image used on the master and agent. Default: /centos-cloud/centos-7-v20160921
+The disk image used on the master and agent. Default: /centos-cloud/centos-7-v20161027
 
 ```text
 bootstrap_public_port


### PR DESCRIPTION
### Summary of Changes

- relates to pull #10 
- corrects the image version of CentOS 7 referenced in README to `v20161027` to match the version in [group_vars/all](group/vars)