### PR TITLE
Fix the scopes option for gce instances create command

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -46,7 +46,7 @@ bootstrap_public_port: 8080
 
 cluster_name: cluster_name
 
-scopes: "default=https://www.googleapis.com/auth/cloud-platform"
+scopes: "https://www.googleapis.com/auth/cloud-platform"
 
 dcos_installer_filename: dcos_generate_config.sh
 

--- a/tasks/create_master_instances.yml
+++ b/tasks/create_master_instances.yml
@@ -16,7 +16,7 @@
       command: "{{ gcloudbin }} compute --project {{ project }} instances create {{ hostvars[item].inventory_hostname }}
              --zone {{ zone }} --machine-type {{ master_machine_type }} --subnet {{ subnet }}
              --private-network-ip  {{ hostvars[item]['ip'] }} --maintenance-policy \"MIGRATE\"  --tags \"master\"
-             --scopes default=https://www.googleapis.com/auth/cloud-platform --image {{ image }} --image-project {{ image_project }}
+             --scopes https://www.googleapis.com/auth/cloud-platform --image {{ image }} --image-project {{ image_project }}
              --boot-disk-size {{ master_boot_disk_size }} --boot-disk-type {{ master_boot_disk_type }}
              --boot-disk-device-name {{ hostvars[item].inventory_hostname }}-boot --metadata hostname={{ hostvars[item].inventory_hostname }}"
       with_items:


### PR DESCRIPTION
Hi, 
The option scopes for the command gcloud compute instances create has changed from 
--scopes=default,SCOPE to --scopes=SCOPE